### PR TITLE
fix ca-certificates issues

### DIFF
--- a/2.10.0/rockcraft.yaml
+++ b/2.10.0/rockcraft.yaml
@@ -4,7 +4,7 @@ description: |
   Grafana Mimir is a horizontally scalable, highly available,
   multi-tenant, long-term storage for Prometheus.
 version: "2.10.0"
-base: ubuntu:22.04
+base: ubuntu@22.04
 license: Apache-2.0
 platforms:
   amd64: {}
@@ -34,3 +34,16 @@ parts:
       opt/mimir/bin/mimir: usr/bin/mimir
       opt/mimir/bin/mimirtool: usr/bin/mimirtool
       opt/mimir/bin/query-tee: usr/bin/query-tee
+  ca-certs:
+    plugin: nil
+    overlay-packages:
+      - ca-certificates
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - mimir
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/2.10.4/rockcraft.yaml
+++ b/2.10.4/rockcraft.yaml
@@ -36,7 +36,7 @@ parts:
       opt/mimir/bin/query-tee: usr/bin/query-tee
   ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil

--- a/2.11.0/rockcraft.yaml
+++ b/2.11.0/rockcraft.yaml
@@ -36,7 +36,7 @@ parts:
       opt/mimir/bin/query-tee: usr/bin/query-tee
   ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil

--- a/2.6.0/rockcraft.yaml
+++ b/2.6.0/rockcraft.yaml
@@ -4,18 +4,15 @@ description: |
   Grafana Mimir is a horizontally scalable, highly available,
   multi-tenant, long-term storage for Prometheus.
 version: "2.6.0"
-base: ubuntu:22.04
+base: ubuntu@22.04
 license: Apache-2.0
-
 platforms:
   amd64: {}
-
 services:
   mimir:
     command: /usr/bin/mimir
     override: replace
     startup: enabled
-
 parts:
   mimir:
     plugin: go
@@ -23,7 +20,7 @@ parts:
     source-type: git
     source-tag: "mimir-2.6.0"
     build-snaps:
-      - go
+      - go/1.20/stable
     build-environment:
       - BUILD_IN_CONTAINER: "false"
     override-build: |
@@ -37,3 +34,16 @@ parts:
       opt/mimir/bin/mimir: usr/bin/mimir
       opt/mimir/bin/mimirtool: usr/bin/mimirtool
       opt/mimir/bin/query-tee: usr/bin/query-tee
+  ca-certs:
+    plugin: nil
+    overlay-packages:
+      - ca-certificates
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - mimir
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

---

Besides that, this PR also makes sure all the rockcraft.yaml files have the same format :)

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```