### PR TITLE
fix: update README on new testing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository holds all the necessary files to build rocks for the upstream ve
 
 The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
 
-New versions of the rock are tested using [`goss`](https://github.com/goss-org/goss) (for the actual validation) and [`noctua`](https://github.com/lucabello/noctua) (to run the actual command).
+New versions of the rock are tested using [`goss`](https://github.com/goss-org/goss) and `kgoss`. To test manually, look at the [testing](#testing) section.
 
 Automation takes care of:
 * validating PRs, by simply trying to build the rock;
@@ -17,3 +17,38 @@ Automation takes care of:
 * on PRs, validate the added (or modified) rocks by running them in a Kubernetes pod and testing them with `goss`;
 * releasing to GHCR at [ghcr.io/canonical/mimir:dev](https://ghcr.io/canonical/mimir:dev), when merging to main, for development purposes.
 
+
+## Testing
+
+**Requirements**: `kubectl` (classic), `microk8s`, `rockcraft`.  
+Make sure that you've run `microk8s enable registry`.
+
+Pack the rock and push it to the local registry:
+
+```bash
+# Pack the rock and push it to the local registry (replace the <variables>)
+rockcraft pack
+rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+  oci-archive:<rock_file> \
+  docker://localhost:32000/<rock_name>:<version>
+```
+
+### Testing with `kgoss`
+
+**Extra Requirements**: `goss`, `kgoss`.
+
+`kgoss` will run the rock in a temporary pod, copy the `goss` binary and checks to the container, and run them from the inside.
+
+```bash
+# Set GOSS_FILES_PATH to the `goss.yaml` folder (default: '.')
+kgoss run -i localhost:32000/<rock_name>:<version>
+```
+
+### Testing manually
+
+For manual exploration, you can run the rock in a pod with only `kubectl`:
+
+```bash
+kubectl run <pod_name> --image=localhost:32000/<rock_name>:<version>
+kubectl exec <pod_name> -it -- /bin/bash
+```

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,6 +1,9 @@
 process:
   mimir:
     running: true
+packagee:
+  ca-certificates:
+    installed: true
 http:
   mimir-config:
     status: 200

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,9 +1,6 @@
 process:
   mimir:
     running: true
-package:
-  ca-certificates:
-    installed: true
 http:
   mimir-config:
     status: 200

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,7 +1,7 @@
 process:
   mimir:
     running: true
-packagee:
+package:
   ca-certificates:
     installed: true
 http:


### PR DESCRIPTION
## Issue
We probably don't need to check that `rockcraft` itself is working correctly (i.e., that it's correctly installing apt packages).


## Solution
Remove the `goss` check on the presence of the `ca-certificates` package.
